### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/zed-extension-release.yml
+++ b/.github/workflows/zed-extension-release.yml
@@ -22,6 +22,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   update-zed-extension:
     name: Bump Zed Extension Version


### PR DESCRIPTION
Potential fix for [https://github.com/xlight/deepseek-visionary/security/code-scanning/4](https://github.com/xlight/deepseek-visionary/security/code-scanning/4)

通用修复方式：在 workflow 根级或具体 job 下增加 `permissions`，仅授予必需权限。若不确定需要写权限，先设为只读最小集（如 `contents: read`），再按运行失败信息逐步加权限。

针对当前文件的最佳且最小变更：在 `.github/workflows/zed-extension-release.yml` 的 `on:` 块之后、`jobs:` 之前新增根级 `permissions`，设置为：

```yml
permissions:
  contents: read
```

这样不会改变现有业务逻辑（仍由 `COMMITTER_TOKEN` 完成写操作），同时满足 CodeQL 对显式权限声明的要求并降低 `GITHUB_TOKEN` 风险面。无需新增 import、方法或依赖。


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
