### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/xlight/deepseek-visionary/security/code-scanning/3](https://github.com/xlight/deepseek-visionary/security/code-scanning/3)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access unless overridden later.

Best fix here (without changing functionality): insert at the top level (after `on:` block is a clear location) the following:

```yml
permissions:
  contents: read
```

This satisfies CodeQL’s requirement and is sufficient for the displayed jobs (`actions/checkout` and local build/test steps). No imports, methods, or external definitions are needed since this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
